### PR TITLE
Fix instructions so install works

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ prepared file hierarchy and create scaffolding for a new project from it.
 Download the latest archive from the Releases page
 
 ```sh
-$ mix archive.install https://github.com/Rastopyr/mix-newer/releases/download/alpha1/mix_newer-0.2.0.ez
+$ mix archive.install https://github.com/Rastopyr/mix-newer/releases/download/alpha2/mix_newer-0.2.0.ez
 ```
 
 or build from source as follows:


### PR DESCRIPTION
# The Problem

After following the readme, the install fails.

```bash
$ mix archive.install https://github.com/Rastopyr/mix-newer/releases/download/alpha1/mix_newer-0.2.0.ez
Are you sure you want to install "https://github.com/Rastopyr/mix-newer/releases/download/alpha1/mix_newer-0.2.0.ez"? [Yn] y
** (Mix) httpc request failed with: {:bad_status_code, 404}

Could not run archive.install for:

    https://github.com/Rastopyr/mix-newer/releases/download/alpha1/mix_newer-0.2.0.ez

Please download the contents above manually to your current directory and run:

    mix archive.install ./mix_newer-0.2.0.ez
```

# The Solution

Update the link in the readme to point to the correct release.

