### PR TITLE
Set rename as optional argument && allow placeholders in template paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ them can be picked in `init.exs` as follows:
 
 ```elixir
 # Decide which file to pick based on the value of our a custom flag
-if flag[:custom] == "second" do
+if flags[:custom] == "second" do
   select "lib/option_2.ex", rename: "{{APP_NAME}}.ex"
 else
   select "lib/option_1.ex", rename: "{{APP_NAME}}.ex"
@@ -129,6 +129,7 @@ end
 The picked file will be kept under the `lib/` directory with a new name, and
 the other file will be removed before the template instantiation completes.
 
+If `rename` option isn't set, default name will be kept.
 
 ### Examples
 

--- a/lib/mix_newer/eval.ex
+++ b/lib/mix_newer/eval.ex
@@ -65,7 +65,7 @@ defmodule MixNewer.Eval do
   end
 
   defp make_env_for(:init) do
-    import MixNewer.Macros, only: [select: 2], warn: false
+    import MixNewer.Macros, only: [select: 1, select: 2], warn: false
     __ENV__
   end
 end

--- a/lib/mix_newer/macros.ex
+++ b/lib/mix_newer/macros.ex
@@ -18,7 +18,7 @@ defmodule MixNewer.Macros do
   end
 
   # Should be available in init.exs
-  defmacro select(template, options) do
+  defmacro select(template, options \\ []) do
     rename = Keyword.get(options, :rename, false)
     quote do
       var!(actions) = var!(actions) ++ [

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MixNewer.Mixfile do
   def project do
     [
       app: :mix_newer,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.0",
       deps: deps()
     ]


### PR DESCRIPTION
- Set `rename` argument as optional in `select` macro (reduces boilerplate code)
  - old_example: `select "ProcFile", rename: "ProcFile"`
  - new_example: `select "ProcFile"
- Sanitization of placeholders inside of template selection paths
- Bump up project subversion
- Fix README.md typo